### PR TITLE
Configurable Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,11 @@ plugins {
     id("com.ekino.oss.gradle.plugin.java") version "1.0.2"
 }
 ```
+
+You can override Java version using a dedicated configuration (default is 11):
+```groovy
+javaPlugin {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+```

--- a/src/main/kotlin/com/ekino/oss/gradle/plugin/java/JavaPlugin.kt
+++ b/src/main/kotlin/com/ekino/oss/gradle/plugin/java/JavaPlugin.kt
@@ -4,7 +4,6 @@
 
 package com.ekino.oss.gradle.plugin.java
 
-import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -16,14 +15,7 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestDescriptor
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestResult
-import org.gradle.kotlin.dsl.apply
-import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByName
-import org.gradle.kotlin.dsl.getValue
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.repositories
-import org.gradle.kotlin.dsl.the
+import org.gradle.kotlin.dsl.*
 import org.unbrokendome.gradle.plugins.testsets.TestSetsPlugin
 import org.unbrokendome.gradle.plugins.testsets.dsl.testSets
 
@@ -32,6 +24,8 @@ class JavaPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     with(project) {
 
+      val javaPluginConfiguration = extensions.create(EXTENSION_NAME, JavaPluginConfiguration::class.java)
+
       // plugins
       apply<org.gradle.api.plugins.JavaPlugin>()
       apply<TestSetsPlugin>()
@@ -39,8 +33,12 @@ class JavaPlugin : Plugin<Project> {
       apply<MavenPublishPlugin>()
 
       // properties
-      setProperty("sourceCompatibility", JavaVersion.VERSION_11)
-      setProperty("targetCompatibility", JavaVersion.VERSION_11)
+      afterEvaluate {
+        with(javaPluginConfiguration) {
+          setProperty("sourceCompatibility", sourceCompatibility)
+          setProperty("targetCompatibility", targetCompatibility)
+        }
+      }
 
       addTasks()
 

--- a/src/main/kotlin/com/ekino/oss/gradle/plugin/java/JavaPluginConfiguration.kt
+++ b/src/main/kotlin/com/ekino/oss/gradle/plugin/java/JavaPluginConfiguration.kt
@@ -1,0 +1,10 @@
+package com.ekino.oss.gradle.plugin.java
+
+import org.gradle.api.JavaVersion
+
+internal const val EXTENSION_NAME = "javaPlugin"
+
+internal open class JavaPluginConfiguration(
+        var sourceCompatibility: JavaVersion = JavaVersion.VERSION_11,
+        var targetCompatibility: JavaVersion = JavaVersion.VERSION_11
+)

--- a/src/test/kotlin/com/ekino/oss/gradle/plugin/JavaPluginIT.kt
+++ b/src/test/kotlin/com/ekino/oss/gradle/plugin/JavaPluginIT.kt
@@ -10,12 +10,7 @@ import org.gradle.testkit.runner.TaskOutcome.SUCCESS
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import strikt.api.expectThat
-import strikt.assertions.contains
-import strikt.assertions.exists
-import strikt.assertions.hasSize
-import strikt.assertions.isEqualTo
-import strikt.assertions.isNotNull
-import strikt.assertions.isNull
+import strikt.assertions.*
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
@@ -104,11 +99,31 @@ class JavaPluginIT {
     }
   }
 
-  private fun runTask(project: String): BuildResult {
+  @Test
+  fun `Should display project's properties with expected Java target`() {
+    val result = runTask("project_with_test", "properties")
+
+    expectThat(result.output) {
+      contains("sourceCompatibility: 1.8")
+      contains("targetCompatibility: 1.8")
+    }
+  }
+
+  @Test
+  fun `Should display project's properties with default Java target`() {
+    val result = runTask("project_with_test_and_integration_test", "properties")
+
+    expectThat(result.output) {
+      contains("sourceCompatibility: 11")
+      contains("targetCompatibility: 11")
+    }
+  }
+
+  private fun runTask(project: String, task: String = "build"): BuildResult {
     File("src/test/resources/$project").copyRecursively(tempDir.toFile())
 
     return GradleRunner.create()
-        .withArguments("build")
+        .withArguments(task)
         .withProjectDir(tempDir.toFile())
         .withTestKitDir(tempDir.toFile())
         .withPluginClasspath()

--- a/src/test/resources/project_with_test/build.gradle
+++ b/src/test/resources/project_with_test/build.gradle
@@ -11,3 +11,8 @@ repositories {
 test {
     useJUnitPlatform()
 }
+
+javaPlugin {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}


### PR DESCRIPTION
I propose you an implementation of #3.

It allows the use of a `javaPlugin` closure to configure the `sourceCompatibility` and the `targetCompatibility`.

By default, it still uses Java 11 as requested.